### PR TITLE
Add: Default timeout in twitter src

### DIFF
--- a/airbyte_client/helper.py
+++ b/airbyte_client/helper.py
@@ -1889,6 +1889,8 @@ class TwitterMentions(AnecdoteConnection):
         }
         if timeout_milliseconds is not None:
             source_configuration['timeout_milliseconds'] = timeout_milliseconds
+        else:
+            source_configuration['timeout_milliseconds'] = 1000
 
         streams_configuration = {
             'tweets': {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a default timeout of 1000 milliseconds to the Twitter source configuration in `airbyte_client/helper.py`.

### Why are these changes being made?

This change ensures that a default timeout is set when no specific timeout is provided, improving the robustness of the Twitter source by preventing potential issues related to undefined timeout values.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->