### PR TITLE
Increase default timeout for twitter

### DIFF
--- a/airbyte_client/helper.py
+++ b/airbyte_client/helper.py
@@ -1890,7 +1890,7 @@ class TwitterMentions(AnecdoteConnection):
         if timeout_milliseconds is not None:
             source_configuration['timeout_milliseconds'] = timeout_milliseconds
         else:
-            source_configuration['timeout_milliseconds'] = 1000
+            source_configuration['timeout_milliseconds'] = 3000
 
         streams_configuration = {
             'tweets': {


### PR DESCRIPTION
**Clickup Ticket:**
https://app.clickup.com/t/8696hhmmp

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the default timeout for the Twitter source configuration from 1000 milliseconds to 3000 milliseconds.

### Why are these changes being made?

The existing timeout setting was causing frequent timeouts when connecting to Twitter's API, leading to failed data fetches. Extending the timeout provides a more reliable data retrieval experience by allowing additional time for the connection to establish and transactions to complete successfully.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->