### PR TITLE
Update: ZendeskConversations enable() to support database params

### DIFF
--- a/airbyte_client/helper.py
+++ b/airbyte_client/helper.py
@@ -2328,12 +2328,15 @@ class ZendeskConversations(AnecdoteConnection):
     def enable(
             self, workspace_id: str, customer_name: str, ind: int, subdomain: str, credentials: Mapping[str, Any],
             use_search_endpoint: Optional[bool] = None, query: Optional[str] = None,
-            start_date: Optional[str] = None
+            start_date: Optional[str] = None,
+            update_database: Optional[bool] = None, source_id: Optional[int] = None,
+            db_host: Optional[str] = None, db_port: Optional[str] = None,
+            db_name: Optional[str] = None, db_user: Optional[str] = None,
+            db_password: Optional[str] = None
     ) -> Tuple[Optional[requests.Response], Optional[Mapping[str, Any]]]:
         if start_date is None:
             start_date = (datetime.today() - timedelta(days=6)).strftime('%Y-%m-%dT%H:%M:%SZ')
         else:
-            # Ensure start_date is in the correct format
             if 'T' not in start_date:
                 start_date = start_date + 'T00:00:00Z'
             elif not start_date.endswith('Z'):
@@ -2351,6 +2354,15 @@ class ZendeskConversations(AnecdoteConnection):
             'use_search_endpoint': use_search_endpoint,
             'query': query,
         }
+
+        if update_database:
+            source_configuration['update_database'] = update_database
+            source_configuration['source_id'] = source_id
+            source_configuration['db_host'] = db_host
+            source_configuration['db_port'] = db_port
+            source_configuration['db_name'] = db_name
+            source_configuration['db_user'] = db_user
+            source_configuration['db_password'] = db_password
 
         streams_configuration = {
             'conversations': {


### PR DESCRIPTION
**Clickup Ticket:**
https://app.clickup.com/t/30360820/VOC-856

Add update_database, source_id, and database connection parameters (db_host, db_port, db_name, db_user, db_password) to align with updated API integration spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `ZendeskConversations.enable()` public interface and starts passing optional DB connection credentials through configuration, which could affect integrations if misused or if callers rely on the old signature.
> 
> **Overview**
> Updates `ZendeskConversations.enable()` to accept optional `update_database`/`source_id` and database connection parameters (`db_host`, `db_port`, `db_name`, `db_user`, `db_password`). When `update_database` is set, these values are added to the generated `source_configuration` sent to Airbyte, aligning the connector setup payload with the updated integration spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5fca63730ca39bc5b6c327134875ac6764a772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->